### PR TITLE
fix(plugin): Correct command registration to prevent NullPointerExcep…

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,6 +9,6 @@ depend:
   - PlaceholderAPI
 
 commands:
-  kartapc:
+  playercontract:
     description: Main command for the Karta PlayerContract plugin.
-    aliases: [kpc, kontrak]
+    aliases: [kartaplayercontract, contract]


### PR DESCRIPTION
…tion

The plugin was attempting to fetch the command "playercontract" which was not registered in plugin.yml, causing a NullPointerException on startup.

This change renames the command from "kartapc" to "playercontract" in plugin.yml to match the code. It also updates the command aliases to /kartaplayercontract and /contract as requested by the user.