### PR TITLE
Fix command handling and improve configuration

### DIFF
--- a/src/main/java/com/playercontract/PlayerContract.java
+++ b/src/main/java/com/playercontract/PlayerContract.java
@@ -28,8 +28,8 @@ public final class PlayerContract extends JavaPlugin {
         reputationManager = new ReputationManager(this);
 
         // Register commands
-        getCommand("playercontract").setExecutor(new com.playercontract.commands.PlayerContractCommand(this));
-        getCommand("playercontract").setTabCompleter(new com.playercontract.commands.PlayerContractCommand(this));
+        getCommand("kartaplayercontract").setExecutor(new com.playercontract.commands.PlayerContractCommand(this));
+        getCommand("kartaplayercontract").setTabCompleter(new com.playercontract.commands.PlayerContractCommand(this));
 
         // Register listeners
         getServer().getPluginManager().registerEvents(new GUIListener(this), this);

--- a/src/main/java/com/playercontract/commands/PlayerContractCommand.java
+++ b/src/main/java/com/playercontract/commands/PlayerContractCommand.java
@@ -72,6 +72,14 @@ public class PlayerContractCommand implements CommandExecutor, TabCompleter {
             case "reputation":
                 handleReputationCommand(sender, args, label);
                 break;
+            case "reload":
+                if (!sender.hasPermission(plugin.getConfigManager().getAdminPermission())) {
+                    sender.sendMessage(plugin.getConfigManager().getMessage("unknown-command", (Player) sender));
+                    return true;
+                }
+                plugin.getConfigManager().reloadConfig();
+                sender.sendMessage(plugin.getConfigManager().getMessage("config-reloaded", (Player) sender));
+                break;
             default:
                 player.sendMessage(plugin.getConfigManager().getMessage("unknown-command", player));
                 break;
@@ -91,9 +99,12 @@ public class PlayerContractCommand implements CommandExecutor, TabCompleter {
                     completions.add(s);
                 }
             }
-            if (sender.hasPermission("kartaquest.admin")) {
+            if (sender.hasPermission(plugin.getConfigManager().getAdminPermission())) {
                 if ("admin".startsWith(args[0].toLowerCase())) {
                     completions.add("admin");
+                }
+                if ("reload".startsWith(args[0].toLowerCase())) {
+                    completions.add("reload");
                 }
             }
             return completions;
@@ -286,7 +297,7 @@ public class PlayerContractCommand implements CommandExecutor, TabCompleter {
     }
 
     private void handleAdminCommand(Player player, String[] args, String label) {
-        if (!player.hasPermission("kartaquest.admin")) {
+        if (!player.hasPermission(plugin.getConfigManager().getAdminPermission())) {
             player.sendMessage(plugin.getConfigManager().getMessage("unknown-command", player)); // Hide admin command
             return;
         }

--- a/src/main/java/com/playercontract/managers/ConfigManager.java
+++ b/src/main/java/com/playercontract/managers/ConfigManager.java
@@ -19,6 +19,7 @@ public class ConfigManager {
     private final MiniMessage miniMessage;
     private final boolean isPapiEnabled;
     private static final Pattern LEGACY_PLACEHOLDER_PATTERN = Pattern.compile("[{$]([^{}$]+)}");
+    private String adminPermission;
 
 
     public ConfigManager(PlayerContract plugin) {
@@ -33,6 +34,8 @@ public class ConfigManager {
         config = plugin.getConfig();
         config.options().copyDefaults(true);
         plugin.saveConfig();
+
+        adminPermission = config.getString("admin-permission", "karta.admin");
     }
 
     public void reloadConfig() {
@@ -88,5 +91,9 @@ public class ConfigManager {
     public Component parse(String message, OfflinePlayer player, TagResolver... placeholders) {
         String formattedMessage = formatString(player, message);
         return miniMessage.deserialize(formattedMessage, placeholders);
+    }
+
+    public String getAdminPermission() {
+        return adminPermission;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,3 +6,4 @@
 # General settings
 max-contracts-per-player: 5
 contract-creation-tax-percent: 5.0
+admin-permission: "karta.admin"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,6 +9,6 @@ depend:
   - PlaceholderAPI
 
 commands:
-  playercontract:
+  kartaplayercontract:
     description: Main command for the Karta PlayerContract plugin.
-    aliases: [kartaplayercontract, contract]
+    aliases: [playercontract, contract]


### PR DESCRIPTION
- Changed the main command to `/kartaplayercontract` with aliases `/playercontract` and `/contract` as requested by the user.
- Made the admin permission node configurable in `config.yml`.
- Added a `/contract reload` alias for the admin reload command for easier use.
- Corrected the command registration in the main plugin class to reflect the changes.