### PR TITLE
Fix Gradle build and compilation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Gradle
+.gradle/
+build/
+target/
+
+# IDE
+.idea/
+*.iml
+*.iws
+.project
+.classpath
+.settings/
+
+# OS
+.DS_Store
+Thumbs.db

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     kotlin("jvm") version "1.9.23"
     id("io.papermc.paperweight.userdev") version "1.7.1"
     id("xyz.jpenilla.run-paper") version "2.2.4"
+    id("com.gradleup.shadow") version "8.3.6"
 }
 
 group = "com.minekarta.karta"
@@ -67,11 +68,12 @@ tasks {
 
     // Configure runServer task for local testing
     runServer {
-        mcVersion = "1.21"
-        paperVersion.set("1.21-4-SNAPSHOT")
-        javaVersion.set(21)
-        // Automatically accept EULA
-        eula.set(true)
+        minecraftVersion("1.21")
+    }
+
+    shadowJar {
+        val bstatsPath = "org.bstats"
+        relocate(bstatsPath, "${project.group}.${project.name.lowercase()}.lib.$bstatsPath")
     }
 }
 
@@ -81,6 +83,5 @@ java {
 
 // Shading bStats
 tasks.reobfJar {
-    val bstatsPath = "org.bstats"
-    relocate(bstatsPath, "${project.group}.${project.name.lowercase()}.lib.$bstatsPath")
+    // This is now handled by the shadowJar task
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,9 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        maven("https://repo.papermc.io/repository/maven-public/")
+    }
+}
+
 rootProject.name = "KartaPlayerContract"

--- a/src/main/kotlin/com/minekarta/karta/playercontract/KartaPlayerContract.kt
+++ b/src/main/kotlin/com/minekarta/karta/playercontract/KartaPlayerContract.kt
@@ -1,5 +1,8 @@
 package com.minekarta.karta.playercontract
 
+import com.minekarta.karta.playercontract.command.ContractCommand
+import com.minekarta.karta.playercontract.config.GuiConfigManager
+import com.minekarta.karta.playercontract.gui.GuiListener
 import com.minekarta.karta.playercontract.persistence.DatabaseManager
 import com.minekarta.karta.playercontract.persistence.SQLiteContractRepository
 import com.minekarta.karta.playercontract.service.ContractService


### PR DESCRIPTION
This commit resolves several issues that were preventing the Gradle project from building successfully.

The following changes were made:
- Updated `build.gradle.kts` to use the correct syntax for the `run-paper` and `shadow` plugins.
- Configured the `shadowJar` task to handle dependency relocation, which was previously being done incorrectly in the `reobfJar` task.
- Added the necessary plugin repositories to `settings.gradle.kts` to allow Gradle to find and download the required plugins.
- Added missing import statements to the main plugin class (`KartaPlayerContract.kt`) to resolve compilation errors.
- Created a `.gitignore` file to exclude build artifacts and IDE files from version control.