### PR TITLE
Fix(gui): Prevent NullPointerException when playing GUI sounds

### DIFF
--- a/src/main/kotlin/com/minekarta/karta/playercontract/gui/BaseGui.kt
+++ b/src/main/kotlin/com/minekarta/karta/playercontract/gui/BaseGui.kt
@@ -97,11 +97,13 @@ abstract class BaseGui(
 
     private fun playSound(soundKey: String) {
         val soundName = plugin.messageManager.getRawMessage(soundKey)
-        try {
-            val sound = Sound.valueOf(soundName.uppercase())
-            player.playSound(player.location, sound, 1.0f, 1.0f)
-        } catch (e: IllegalArgumentException) {
-            plugin.logger.warning("Invalid sound name in messages.yml: $soundName")
+        if (soundName.isNotBlank() && !soundName.startsWith("Message not found:")) {
+            try {
+                val sound = Sound.valueOf(soundName.uppercase())
+                player.playSound(player.location, sound, 1.0f, 1.0f)
+            } catch (e: IllegalArgumentException) {
+                plugin.logger.warning("Invalid sound name in messages.yml: $soundName")
+            }
         }
     }
 }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -30,3 +30,7 @@ gui:
   delivery-inbox-title: "<blue>Delivery Inbox"
   history-title: "<blue>Contract History"
   statistics-title: "<blue>Player Statistics"
+
+  # Sound effects for GUI interactions
+  open-sound: "BLOCK_CHEST_OPEN"
+  click-sound: "UI_BUTTON_CLICK"


### PR DESCRIPTION
A NullPointerException would occur in the `playSound` method of `BaseGui` if the sound keys (`gui.open-sound`, `gui.click-sound`) were missing from the `messages.yml` file.

This was because `MessageManager` would return a default "Message not found" string, which, when passed to `Sound.valueOf()`, caused an internal error.

This commit resolves the issue in two ways:
1.  Adds the missing `open-sound` and `click-sound` keys to the default `messages.yml` file.
2.  Adds a guard clause to the `playSound` method to ensure the sound name is valid before attempting to play it, making the system more robust against misconfigurations.